### PR TITLE
Support Angular 1.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,9 +23,6 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2.0"
-  },
-  "resolutions": {
-    "angular": "~1.2.0"
+    "angular": ">=1.2.0"
   }
 }


### PR DESCRIPTION
I tested ngScrollTo on 1.3.0 and it seems to work fine. I updated the dependencies accordingly. Note also that I removed the resolutions declaration -- there are no conflicts in the dep versions (there is only one dep) so resolutions should be unnecessary.
