### PR TITLE
Target elements are now focused by default

### DIFF
--- a/ng-scrollto.js
+++ b/ng-scrollto.js
@@ -38,11 +38,15 @@ angular.module('ngScrollTo')
 angular.module("ngScrollTo")
   .service('ScrollTo', ['$window', function($window) {
 
-    this.idOrName = function (idOrName, offset) {//find element with the given id or name and scroll to the first element it finds
+    this.idOrName = function (idOrName, offset, focus) {//find element with the given id or name and scroll to the first element it finds
         var document = $window.document;
         
         if(!idOrName) {//move to top if idOrName is not provided
           $window.scrollTo(0, 0);
+        }
+
+        if(focus === undefined) { //set default action to focus element
+            focus = true;
         }
 
         //check if an element can be found with id attribute
@@ -57,6 +61,9 @@ angular.module("ngScrollTo")
         }
 
         if(el) { //if an element is found, scroll to the element
+          if (focus) {
+              el.focus();
+          }
           if (offset) {
             var top = $(el).offset().top - offset;
             window.scrollTo(0, top);


### PR DESCRIPTION
When an anchor pointing to an element is clicked, in addition to scroll to the target element, it will focus it.

This update fulfills the accessibility flaw when special users use the interface, those who rely on the TAB key to navigate in the page, like blind users or users with movement disability.

Note: In my opinion, for browser compatibility and user experience, you shouldn't use scrollIntoView(). For example, if you use only keyboard and click enter on the anchor, it will only scroll to the target element. If you make tab again, it will scroll all the way back where it was before when you clicked and not on the target element.

Please check this guideline and topics:
http://www.w3.org/TR/WCAG20-TECHS/SCR35.html
http://www.w3.org/TR/2009/WD-wai-aria-practices-20090224/#scrollintoview
http://www.quirksmode.org/dom/w3c_cssom.html
