### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ fiddle : [http://jsfiddle.net/8Mtxc/230/](http://jsfiddle.net/8Mtxc/230/)
 ```
 
 
-##Usage
-###Default
+## Usage
+### Default
 
 ``` javascript
 angular.module("myApp", ["ngScrollTo"]);
 ```
-###Custom action
+### Custom action
 Example: [http://jsfiddle.net/8Mtxc/231/](http://jsfiddle.net/8Mtxc/231/)
 ``` javascript
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
